### PR TITLE
Update to .NET 10

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -7,11 +7,12 @@ on:
 
 permissions:
   packages: write
+  contents: read
 
 env:
-  MAJOR: 3
+  MAJOR: 4
   MINOR: 0
-  MINORMINOR: 1 
+  MINORMINOR: 0
   RUN: ${{ github.run_number }}
 
 jobs:
@@ -19,36 +20,38 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
 
       - name: Restore dependencies
         run: |
           nuget sources add -username Open-Systems-Pharmacology -password ${{ secrets.GITHUB_TOKEN }} -name OSP-GitHub-Packages -source "https://nuget.pkg.github.com/Open-Systems-Pharmacology/index.json"
-          nuget restore
+          dotnet restore OSPSuite.DataBinding.sln
 
       - name: define env variables
         run: |
           echo "APP_VERSION=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.MINORMINOR }}.${{ env.RUN }}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Build
-        run: msbuild OSPSuite.DataBinding.sln /p:Version=${{env.APP_VERSION}}
+        run: dotnet build OSPSuite.DataBinding.sln --no-restore -p:Version=${{env.APP_VERSION}}
 
       - name : Test
-        run: dotnet test .\tests\OSPSuite.DataBinding.Tests\bin\Debug\net8.0*\OSPSuite*Tests.dll -v normal --logger:"html;LogFileName=../testLog_Windows.html"
+        run: dotnet test OSPSuite.DataBinding.sln -v normal --no-build --configuration Debug --logger:"html;LogFileName=../testLog_Windows.html"
 
       - name: Pack the project
         run: dotnet pack .\OSPSuite.DataBinding.sln --no-build --no-restore -o ./ -p:PackageVersion=${{env.APP_VERSION}} --configuration=Debug
 
       - name: Push test log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testLog_Windows
-          path: ./testLog*.html
+          path: ./**/testLog*.html
 
       - name: Publish to GitHub registry
         run: dotnet nuget push *.nupkg --source https://nuget.pkg.github.com/${{github.repository_owner}}/index.json --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,10 +5,14 @@ on:
     branches:
     - main
 
+permissions:
+  packages: read
+  contents: read
+
 env:
-  MAJOR: 3
+  MAJOR: 4
   MINOR: 0
-  MINORMINOR: 1 
+  MINORMINOR: 0
   RUN: ${{ github.run_number }}
 
 jobs:
@@ -16,39 +20,41 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
 
       - name: Restore dependencies
         run: |
           nuget sources add -username Open-Systems-Pharmacology -password ${{ secrets.GITHUB_TOKEN }} -name OSP-GitHub-Packages -source "https://nuget.pkg.github.com/Open-Systems-Pharmacology/index.json"
-          nuget restore
+          dotnet restore OSPSuite.DataBinding.sln
 
       - name: define env variables
         run: |
           echo "APP_VERSION=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.MINORMINOR }}.${{ env.RUN }}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Build
-        run: msbuild OSPSuite.DataBinding.sln /p:Version=${{env.APP_VERSION}}
+        run: dotnet build OSPSuite.DataBinding.sln --no-restore -p:Version=${{env.APP_VERSION}}
 
       - name : Test
-        run: dotnet test .\tests\OSPSuite.DataBinding.Tests\bin\Debug\net8.0*\OSPSuite*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"
+        run: dotnet test OSPSuite.DataBinding.sln -v normal --no-build --configuration Debug --logger:"html;LogFileName=../testLog_Windows.html"
 
       - name: Pack the project
         run: dotnet pack .\OSPSuite.DataBinding.sln --no-build --no-restore -o ./ -p:PackageVersion=${{env.APP_VERSION}} --configuration=Debug
 
       - name: Push nupkg as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OSPSuite.DataBinding
           path: ./*.nupkg
 
       - name: Push test log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testLog_Windows
-          path: ./testLog*.html
+          path: ./**/testLog*.html

--- a/src/OSPSuite.DataBinding/OSPSuite.DataBinding.csproj
+++ b/src/OSPSuite.DataBinding/OSPSuite.DataBinding.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageProjectUrl>https://github.com/Open-Systems-Pharmacology/OSPSuite.DataBinding</PackageProjectUrl>
@@ -21,7 +21,7 @@
     <Compile Include="..\..\SolutionInfo.cs" Link="Properties\SolutionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/tests/OSPSuite.DataBinding.Starter/OSPSuite.DataBinding.Starter.csproj
+++ b/tests/OSPSuite.DataBinding.Starter/OSPSuite.DataBinding.Starter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -20,6 +20,6 @@
     <ProjectReference Include="..\..\src\OSPSuite.DataBinding\OSPSuite.DataBinding.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.6" />
   </ItemGroup>
 </Project>

--- a/tests/OSPSuite.DataBinding.Tests/OSPSuite.DataBinding.Tests.csproj
+++ b/tests/OSPSuite.DataBinding.Tests/OSPSuite.DataBinding.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -23,11 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Retarget all projects (`OSPSuite.DataBinding`, tests, starter) from `net8.0-windows` to `net10.0-windows`.
- Bump `OSPSuite.Utility` reference from `4.1.1.4` → `5.0.0.6` (the .NET 10 build).
- Bump published package major: `3.0.1` → `4.0.0`.
- Modernize both GHA workflows: `actions/checkout@v6`, `actions/setup-dotnet@v5` (10.x), `actions/upload-artifact@v7`. Drop `microsoft/setup-msbuild` and build with `dotnet build/test/pack` to avoid the VS 2022 17.14 net10 warning. Recursive `testLog` glob (`./**/testLog*.html`).
- Add explicit `permissions:` blocks to both workflows (`packages: write` + `contents: read` on publish, `packages: read` + `contents: read` on PR build) to clear code-scanning warnings.
- Drop redundant `Microsoft.CSharp` PackageReference from the test project (NU1510 — pruned by net10).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` — 53/53 passed locally
- [x] `dotnet pack` succeeds; produced `OSPSuite.DataBinding.4.0.0.nupkg`
- [x] PR build workflow runs green on GHA
- [ ] After merge, publish workflow pushes `4.0.0.x` to GitHub Packages

Fixes #19
Fixes #18